### PR TITLE
Fix permissions on Android 14+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/at/plankt0n/wamediacopy/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/MainActivity.kt
@@ -46,8 +46,9 @@ class MainActivity : AppCompatActivity() {
 
     private fun checkPermissions() {
         val perms = arrayOf(
-            Manifest.permission.READ_EXTERNAL_STORAGE,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            Manifest.permission.READ_MEDIA_IMAGES,
+            Manifest.permission.READ_MEDIA_VIDEO,
+            Manifest.permission.READ_MEDIA_AUDIO,
             Manifest.permission.POST_NOTIFICATIONS,
         )
         val needed = perms.filter {

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -193,8 +193,9 @@ class SettingsFragment : Fragment() {
         val missing = mutableListOf<String>()
         val ctx = requireContext()
         val storagePerms = arrayOf(
-            android.Manifest.permission.READ_EXTERNAL_STORAGE,
-            android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            android.Manifest.permission.READ_MEDIA_IMAGES,
+            android.Manifest.permission.READ_MEDIA_VIDEO,
+            android.Manifest.permission.READ_MEDIA_AUDIO,
             android.Manifest.permission.POST_NOTIFICATIONS
         )
         val needReq = storagePerms.filter {


### PR DESCRIPTION
## Summary
- request the new READ_MEDIA_* permissions instead of deprecated storage perms
- update permission check logic in SettingsFragment
- update AndroidManifest to declare new permissions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d568708c832fb8f3f3291d1b1f8b