### PR TITLE
Implement UI lock and live copy stats

### DIFF
--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -49,7 +49,7 @@ class FileCopyWorker(
         }
         val sources = prefs.getStringSet(PREF_SOURCES, emptySet()) ?: emptySet()
         val destUri = prefs.getString(PREF_DEST, null)
-        val maxAgeHours = prefs.getInt(PREF_MAX_AGE_HOURS, 24)
+        val maxAgeMinutes = prefs.getInt(PREF_MAX_AGE_MINUTES, 24 * 60)
         val copyMode = prefs.getInt(PREF_COPY_MODE, 0)
         val lastCopy = prefs.getLong(PREF_LAST_COPY, 0L)
         val intervalMin = prefs.getInt(PREF_INTERVAL_MINUTES, 0)
@@ -100,7 +100,7 @@ class FileCopyWorker(
 
         val startTs = System.currentTimeMillis()
         val cutoff = if (copyMode == 0) {
-            startTs - maxAgeHours * 3600_000L
+            startTs - maxAgeMinutes * 60_000L
         } else {
             lastCopy
         }
@@ -210,7 +210,7 @@ class FileCopyWorker(
         const val PREF_SOURCES = "sources"
         const val PREF_DEST = "dest"
         const val PREF_ALIAS = "alias"
-        const val PREF_MAX_AGE_HOURS = "maxAgeH"
+        const val PREF_MAX_AGE_MINUTES = "maxAgeM"
         const val PREF_COPIED = "copiedFiles"
         const val PREF_LAST_COPY = "lastCopy"
         const val PREF_NEXT_COPY = "nextCopy"

--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -61,7 +61,12 @@ class FileCopyWorker(
         var alreadySkipped = 0L
         var processed = 0L
 
-        prefs.edit().putLong(PREF_PROCESSED, 0L).apply()
+        prefs.edit()
+            .putLong(PREF_PROCESSED, 0L)
+            .putLong(PREF_COUNT_COPIED, 0L)
+            .putLong(PREF_COUNT_OLD, 0L)
+            .putLong(PREF_COUNT_SKIPPED, 0L)
+            .apply()
         setForeground(createForegroundInfo(0L))
         val manual = inputData.getBoolean(KEY_MANUAL, false)
         if (!manual && requireManual) {
@@ -111,7 +116,9 @@ class FileCopyWorker(
                     traverse(doc)
                 } else if (doc.isFile) {
                     processed++
-                    prefs.edit().putLong(PREF_PROCESSED, processed).apply()
+                    prefs.edit()
+                        .putLong(PREF_PROCESSED, processed)
+                        .apply()
                     setForeground(createForegroundInfo(processed))
                     if (doc.lastModified() >= cutoff) {
                         val key = doc.uri.toString()
@@ -146,6 +153,7 @@ class FileCopyWorker(
                                     Log.d(TAG, "Copied file")
                                     copied.add(key)
                                     newCount++
+                                    prefs.edit().putLong(PREF_COUNT_COPIED, newCount).apply()
                                 }
                             } catch (e: Exception) {
                                 Log.w(TAG, "Failed to copy file", e)
@@ -153,10 +161,12 @@ class FileCopyWorker(
                         } else {
                             Log.d(TAG, "Already copied file")
                             alreadySkipped++
+                            prefs.edit().putLong(PREF_COUNT_SKIPPED, alreadySkipped).apply()
                         }
                     } else {
                         Log.d(TAG, "Too old file")
                         oldSkipped++
+                        prefs.edit().putLong(PREF_COUNT_OLD, oldSkipped).apply()
                     }
                 }
             }
@@ -189,6 +199,9 @@ class FileCopyWorker(
             prefs.edit()
                 .putBoolean(PREF_IS_RUNNING, false)
                 .remove(PREF_PROCESSED)
+                .remove(PREF_COUNT_COPIED)
+                .remove(PREF_COUNT_OLD)
+                .remove(PREF_COUNT_SKIPPED)
                 .apply()
         }
     }
@@ -205,6 +218,9 @@ class FileCopyWorker(
         const val PREF_INTERVAL_MINUTES = "intervalM"
         const val PREF_IS_RUNNING = "copyRunning"
         const val PREF_PROCESSED = "processed"
+        const val PREF_COUNT_COPIED = "countCopied"
+        const val PREF_COUNT_OLD = "countOld"
+        const val PREF_COUNT_SKIPPED = "countSkipped"
         const val PREF_REQUIRE_MANUAL_FIRST = "requireManual"
         const val KEY_MANUAL = "manual"
         const val CHANNEL_ID = "copy_status"

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -187,6 +187,9 @@ class SettingsFragment : Fragment(),
         }
         val running = prefs.getBoolean(FileCopyWorker.PREF_IS_RUNNING, false)
         val processed = prefs.getLong(FileCopyWorker.PREF_PROCESSED, 0L)
+        val copied = prefs.getLong(FileCopyWorker.PREF_COUNT_COPIED, 0L)
+        val skipped = prefs.getLong(FileCopyWorker.PREF_COUNT_SKIPPED, 0L)
+        val old = prefs.getLong(FileCopyWorker.PREF_COUNT_OLD, 0L)
 
         manual.isEnabled = !running
         aliasEdit.isEnabled = !running
@@ -198,7 +201,9 @@ class SettingsFragment : Fragment(),
         checkPerms.isEnabled = !running
 
         val base = "$lastLabel\n$nextLabel"
-        val combined = if (running) "$base\nProcessed: $processed" else base
+        val combined = if (running) {
+            "$base\nProcessed: $processed\nCopied: $copied\nSkipped: $skipped\nToo old: $old"
+        } else base
         lastCopyText.text = combined
     }
 
@@ -332,7 +337,10 @@ class SettingsFragment : Fragment(),
         if (key == FileCopyWorker.PREF_IS_RUNNING ||
             key == FileCopyWorker.PREF_PROCESSED ||
             key == FileCopyWorker.PREF_LAST_COPY ||
-            key == FileCopyWorker.PREF_NEXT_COPY) {
+            key == FileCopyWorker.PREF_NEXT_COPY ||
+            key == FileCopyWorker.PREF_COUNT_COPIED ||
+            key == FileCopyWorker.PREF_COUNT_SKIPPED ||
+            key == FileCopyWorker.PREF_COUNT_OLD) {
             refreshLastCopy(prefs)
         }
     }

--- a/app/src/main/java/at/plankt0n/wamediacopy/StatusNotifier.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/StatusNotifier.kt
@@ -11,17 +11,33 @@ object StatusNotifier {
     private const val RESULT_ID = 2
     const val CHANNEL_ID = "copy_status"
 
-    fun showService(context: Context, processed: Long? = null) {
+    fun showService(
+        context: Context,
+        processed: Long? = null,
+        nextCopy: Long? = null,
+        showCountdown: Boolean = false
+    ) {
         val channel = NotificationChannel(CHANNEL_ID, "Copy status", NotificationManager.IMPORTANCE_LOW)
         val nm = context.getSystemService(NotificationManager::class.java)
         nm.createNotificationChannel(channel)
-        val text = processed?.let { "Files Processed: $it" } ?: ""
-        val notif = NotificationCompat.Builder(context, CHANNEL_ID)
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle("Whatsapp Copy")
-            .setContentText(text)
             .setSmallIcon(android.R.drawable.stat_notify_sync)
-            .setOngoing(true)
-            .build()
+
+        val text = processed?.let { "Files Processed: $it" } ?: if (showCountdown && nextCopy != null) {
+            "Next copy in"
+        } else {
+            ""
+        }
+
+        builder.setContentText(text)
+
+        if (processed == null && showCountdown && nextCopy != null) {
+            builder.setWhen(nextCopy)
+                .setUsesChronometer(true)
+                .setChronometerCountDown(true)
+        }
+        val notif = builder.setOngoing(true).build()
         NotificationManagerCompat.from(context).notify(SERVICE_ID, notif)
     }
 

--- a/app/src/main/res/layout/dialog_duration.xml
+++ b/app/src/main/res/layout/dialog_duration.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <NumberPicker
+            android:id="@+id/picker_weeks"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content" />
+        <NumberPicker
+            android:id="@+id/picker_days"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp">
+        <NumberPicker
+            android:id="@+id/picker_hours"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content" />
+        <NumberPicker
+            android:id="@+id/picker_minutes"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_duration.xml
+++ b/app/src/main/res/layout/dialog_duration.xml
@@ -9,11 +9,28 @@
         android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:text="Weeks" />
         <NumberPicker
             android:id="@+id/picker_weeks"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:text="Days" />
         <NumberPicker
             android:id="@+id/picker_days"
             android:layout_width="0dp"
@@ -26,11 +43,28 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:text="Hours" />
         <NumberPicker
             android:id="@+id/picker_hours"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:text="Minutes" />
         <NumberPicker
             android:id="@+id/picker_minutes"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -57,12 +57,13 @@
             android:layout_marginTop="8dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-            <Button
-                android:id="@+id/button_interval"
-                android:text="Set interval"
+            <SeekBar
+                android:id="@+id/seek_interval"
                 android:layout_weight="1"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:max="4320"
+                android:min="1" />
             <TextView
                 android:id="@+id/text_interval"
                 android:layout_marginStart="8dp"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -20,17 +20,16 @@
             android:layout_marginTop="8dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-            <SeekBar
-                android:id="@+id/seek_age"
+            <Button
+                android:id="@+id/button_age"
+                android:text="Set age"
                 android:layout_weight="1"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:max="30"
-                android:min="1" />
+                android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/text_age"
                 android:layout_marginStart="8dp"
-                android:text="1 Tag"
+                android:text="1 day"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
         </LinearLayout>
@@ -58,13 +57,12 @@
             android:layout_marginTop="8dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-            <SeekBar
-                android:id="@+id/seek_interval"
+            <Button
+                android:id="@+id/button_interval"
+                android:text="Set interval"
                 android:layout_weight="1"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:max="144"
-                android:min="1" />
+                android:layout_height="wrap_content" />
             <TextView
                 android:id="@+id/text_interval"
                 android:layout_marginStart="8dp"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -34,6 +34,7 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
+
         <RadioGroup
             android:id="@+id/radio_mode"
             android:orientation="vertical"
@@ -80,6 +81,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
+        <Switch
+            android:id="@+id/switch_countdown"
+            android:text="Show Time Until next Copy"
+            android:layout_marginTop="4dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
         <LinearLayout
             android:orientation="horizontal"
             android:layout_marginTop="8dp"
@@ -98,6 +106,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
         </LinearLayout>
+
+        <ProgressBar
+            android:id="@+id/progress_files"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:max="100"
+            android:layout_marginTop="4dp" />
 
         <Button
             android:id="@+id/button_stop"


### PR DESCRIPTION
## Summary
- disable folder editing while a copy is running
- record counts for copied, skipped and old files during a run
- display those counts live in the settings screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710ff6cdc8832f941225e67388f018