### PR TITLE
Improve URI display and interval handling

### DIFF
--- a/app/src/main/java/at/plankt0n/wamediacopy/BlacklistFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/BlacklistFragment.kt
@@ -81,7 +81,7 @@ class BlacklistFragment : Fragment() {
     private fun refresh(prefs: android.content.SharedPreferences) {
         listLayout.removeAllViews()
         for (uri in copied) {
-            val cb = CheckBox(requireContext()).apply { text = uri }
+            val cb = CheckBox(requireContext()).apply { text = Uri.decode(uri) }
             listLayout.addView(cb)
         }
         countText.text = "Count: ${copied.size}"

--- a/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
@@ -18,7 +18,7 @@ class BootReceiver : BroadcastReceiver() {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             if (prefs.getBoolean(SettingsFragment.PREF_ENABLED, true)) {
                 val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-                val period = if (minutes < 15) 15L else minutes.toLong()
+                val period = minutes.coerceAtLeast(15).toLong()
                 val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES).build()
                 WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                     SettingsFragment.WORK_NAME,
@@ -27,7 +27,7 @@ class BootReceiver : BroadcastReceiver() {
                 )
                 val last = prefs.getLong(FileCopyWorker.PREF_LAST_COPY, 0L)
                 val base = if (last > 0L) maxOf(System.currentTimeMillis(), last) else System.currentTimeMillis()
-                val next = base + minutes * 60_000L
+                val next = base + period * 60_000L
                 prefs.edit()
                     .putBoolean(FileCopyWorker.PREF_IS_RUNNING, false)
                     .remove(FileCopyWorker.PREF_PROCESSED)

--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -194,8 +194,9 @@ class FileCopyWorker(
                     stop = true
                     break
                 }
-                Log.d(TAG, "Processing source $src")
-                AppLog.add(applicationContext, "Processing source $src")
+                val decoded = Uri.decode(src)
+                Log.d(TAG, "Processing source $decoded")
+                AppLog.add(applicationContext, "Processing source $decoded")
                 val sDir = DocumentFile.fromTreeUri(applicationContext, Uri.parse(src))
                 if (sDir != null && sDir.isDirectory) {
                     traverse(sDir)
@@ -221,7 +222,8 @@ class FileCopyWorker(
             AppLog.add(applicationContext, summary)
 
             if (intervalMin > 0) {
-                val nextScheduled = now + intervalMin * 60_000L
+                val periodMin = maxOf(intervalMin, 15)
+                val nextScheduled = now + periodMin * 60_000L
                 prefs.edit().putLong(PREF_NEXT_COPY, nextScheduled).apply()
             }
 

--- a/app/src/main/java/at/plankt0n/wamediacopy/FoldersFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FoldersFragment.kt
@@ -82,11 +82,12 @@ class FoldersFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeLi
             }
             val remove = Button(requireContext()).apply { text = "X" }
             remove.setOnClickListener {
-                Log.d(TAG, "remove source $uri")
+                val decoded = Uri.decode(uri)
+                Log.d(TAG, "remove source $decoded")
                 sources.remove(uri)
                 prefs.edit().putStringSet(FileCopyWorker.PREF_SOURCES, sources.toSet()).apply()
                 refreshSources(prefs)
-                AppLog.add(requireContext(), "Removed source $uri")
+                AppLog.add(requireContext(), "Removed source $decoded")
             }
             row.addView(tv)
             row.addView(remove)
@@ -106,15 +107,17 @@ class FoldersFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeLi
             )
             when (requestCode) {
                 REQ_PICK_SOURCE -> {
-                    sources.add(uri.toString())
+                    val uriStr = uri.toString()
+                    sources.add(uriStr)
                     prefs.edit().putStringSet(FileCopyWorker.PREF_SOURCES, sources.toSet()).apply()
                     refreshSources(prefs)
-                    AppLog.add(requireContext(), "Added source $uri")
+                    AppLog.add(requireContext(), "Added source ${Uri.decode(uriStr)}")
                 }
                 REQ_PICK_DEST -> {
-                    destEdit.setText(Uri.decode(uri.toString()))
-                    prefs.edit().putString(FileCopyWorker.PREF_DEST, uri.toString()).apply()
-                    AppLog.add(requireContext(), "Set destination $uri")
+                    val uriStr = uri.toString()
+                    destEdit.setText(Uri.decode(uriStr))
+                    prefs.edit().putString(FileCopyWorker.PREF_DEST, uriStr).apply()
+                    AppLog.add(requireContext(), "Set destination ${Uri.decode(uriStr)}")
                 }
             }
         }

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -294,14 +294,14 @@ class SettingsFragment : Fragment(),
         if (prefs.getLong(FileCopyWorker.PREF_LAST_COPY, 0L) == 0L) {
             prefs.edit().putBoolean(FileCopyWorker.PREF_REQUIRE_MANUAL_FIRST, true).apply()
         }
-        val period = if (minutes < 15) 15L else minutes.toLong()
+        val period = minutes.coerceAtLeast(15)
         val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
             .addTag(FileCopyWorker.TAG)
             .build()
         manager.enqueueUniquePeriodicWork(WORK_NAME, ExistingPeriodicWorkPolicy.UPDATE, request)
         val last = prefs.getLong(FileCopyWorker.PREF_LAST_COPY, 0L)
         val base = if (last > 0L) maxOf(System.currentTimeMillis(), last) else System.currentTimeMillis()
-        val next = base + minutes * 60_000L
+        val next = base + period * 60_000L
         prefs.edit()
             .putBoolean(FileCopyWorker.PREF_IS_RUNNING, false)
             .putLong(FileCopyWorker.PREF_PROCESSED, 0L)
@@ -322,7 +322,7 @@ class SettingsFragment : Fragment(),
 
         if (toggle.isChecked) {
             val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-            val period = if (minutes < 15) 15L else minutes.toLong()
+            val period = minutes.coerceAtLeast(15)
             val requestPeriodic =
                 PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
                     .addTag(FileCopyWorker.TAG)
@@ -334,7 +334,7 @@ class SettingsFragment : Fragment(),
             )
             val last = prefs.getLong(FileCopyWorker.PREF_LAST_COPY, 0L)
             val base = if (last > 0L) maxOf(System.currentTimeMillis(), last) else System.currentTimeMillis()
-            val next = base + minutes * 60_000L
+            val next = base + period * 60_000L
             prefs.edit().putLong(FileCopyWorker.PREF_NEXT_COPY, next).apply()
         }
         prefs.edit().putLong(FileCopyWorker.PREF_PROCESSED, 0L).apply()

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -294,7 +294,7 @@ class SettingsFragment : Fragment(),
         if (prefs.getLong(FileCopyWorker.PREF_LAST_COPY, 0L) == 0L) {
             prefs.edit().putBoolean(FileCopyWorker.PREF_REQUIRE_MANUAL_FIRST, true).apply()
         }
-        val period = minutes.coerceAtLeast(15)
+        val period = minutes.coerceAtLeast(15).toLong()
         val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
             .addTag(FileCopyWorker.TAG)
             .build()
@@ -322,7 +322,7 @@ class SettingsFragment : Fragment(),
 
         if (toggle.isChecked) {
             val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-            val period = minutes.coerceAtLeast(15)
+            val period = minutes.coerceAtLeast(15).toLong()
             val requestPeriodic =
                 PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
                     .addTag(FileCopyWorker.TAG)


### PR DESCRIPTION
## Summary
- decode URIs before displaying them in the UI and logs
- compute next run time using the actual period when scheduling work
- show decoded URIs in blacklist

## Testing
- `./gradlew test --console=plain --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713adca970832f83e122c53bedd4f2