### PR TITLE
Set minimum interval to 3 minutes

### DIFF
--- a/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
@@ -18,7 +18,7 @@ class BootReceiver : BroadcastReceiver() {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             if (prefs.getBoolean(SettingsFragment.PREF_ENABLED, true)) {
                 val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-                val period = minutes.coerceAtLeast(3).toLong()
+                val period = minutes.coerceAtLeast(15).toLong()
                 val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES).build()
                 WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                     SettingsFragment.WORK_NAME,

--- a/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
@@ -18,7 +18,7 @@ class BootReceiver : BroadcastReceiver() {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             if (prefs.getBoolean(SettingsFragment.PREF_ENABLED, true)) {
                 val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-                val period = minutes.coerceAtLeast(15).toLong()
+                val period = minutes.coerceAtLeast(FileCopyWorker.MIN_INTERVAL_MINUTES).toLong()
                 val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES).build()
                 WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                     SettingsFragment.WORK_NAME,

--- a/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
@@ -18,7 +18,7 @@ class BootReceiver : BroadcastReceiver() {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             if (prefs.getBoolean(SettingsFragment.PREF_ENABLED, true)) {
                 val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-                val period = minutes.coerceAtLeast(15).toLong()
+                val period = minutes.coerceAtLeast(3).toLong()
                 val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES).build()
                 WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                     SettingsFragment.WORK_NAME,

--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -222,7 +222,7 @@ class FileCopyWorker(
             AppLog.add(applicationContext, summary)
 
             if (intervalMin > 0) {
-                val periodMin = maxOf(intervalMin, 3)
+                val periodMin = maxOf(intervalMin, 15)
                 val nextScheduled = now + periodMin * 60_000L
                 prefs.edit().putLong(PREF_NEXT_COPY, nextScheduled).apply()
             }

--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -222,7 +222,7 @@ class FileCopyWorker(
             AppLog.add(applicationContext, summary)
 
             if (intervalMin > 0) {
-                val periodMin = maxOf(intervalMin, 15)
+                val periodMin = maxOf(intervalMin, MIN_INTERVAL_MINUTES)
                 val nextScheduled = now + periodMin * 60_000L
                 prefs.edit().putLong(PREF_NEXT_COPY, nextScheduled).apply()
             }
@@ -261,6 +261,7 @@ class FileCopyWorker(
     }
 
     companion object {
+        const val MIN_INTERVAL_MINUTES = 15
         const val PREF_SOURCES = "sources"
         const val PREF_DEST = "dest"
         const val PREF_ALIAS = "alias"

--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -222,7 +222,7 @@ class FileCopyWorker(
             AppLog.add(applicationContext, summary)
 
             if (intervalMin > 0) {
-                val periodMin = maxOf(intervalMin, 15)
+                val periodMin = maxOf(intervalMin, 3)
                 val nextScheduled = now + periodMin * 60_000L
                 prefs.edit().putLong(PREF_NEXT_COPY, nextScheduled).apply()
             }

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -294,7 +294,7 @@ class SettingsFragment : Fragment(),
         if (prefs.getLong(FileCopyWorker.PREF_LAST_COPY, 0L) == 0L) {
             prefs.edit().putBoolean(FileCopyWorker.PREF_REQUIRE_MANUAL_FIRST, true).apply()
         }
-        val period = minutes.coerceAtLeast(15).toLong()
+        val period = minutes.coerceAtLeast(3).toLong()
         val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
             .addTag(FileCopyWorker.TAG)
             .build()
@@ -322,7 +322,7 @@ class SettingsFragment : Fragment(),
 
         if (toggle.isChecked) {
             val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-            val period = minutes.coerceAtLeast(15).toLong()
+            val period = minutes.coerceAtLeast(3).toLong()
             val requestPeriodic =
                 PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
                     .addTag(FileCopyWorker.TAG)
@@ -426,7 +426,7 @@ class SettingsFragment : Fragment(),
     }
 
     private fun minutesToSlider(minutes: Int): Float {
-        val min = 1f
+        val min = 3f
         val max = 43200f
         val minLog = ln(min)
         val maxLog = ln(max)
@@ -435,7 +435,7 @@ class SettingsFragment : Fragment(),
     }
 
     private fun sliderToMinutes(value: Float): Int {
-        val min = 1f
+        val min = 3f
         val max = 43200f
         val minLog = ln(min)
         val maxLog = ln(max)

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -294,7 +294,7 @@ class SettingsFragment : Fragment(),
         if (prefs.getLong(FileCopyWorker.PREF_LAST_COPY, 0L) == 0L) {
             prefs.edit().putBoolean(FileCopyWorker.PREF_REQUIRE_MANUAL_FIRST, true).apply()
         }
-        val period = minutes.coerceAtLeast(15).toLong()
+        val period = minutes.coerceAtLeast(FileCopyWorker.MIN_INTERVAL_MINUTES).toLong()
         val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
             .addTag(FileCopyWorker.TAG)
             .build()
@@ -322,7 +322,7 @@ class SettingsFragment : Fragment(),
 
         if (toggle.isChecked) {
             val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-            val period = minutes.coerceAtLeast(15).toLong()
+            val period = minutes.coerceAtLeast(FileCopyWorker.MIN_INTERVAL_MINUTES).toLong()
             val requestPeriodic =
                 PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
                     .addTag(FileCopyWorker.TAG)
@@ -426,7 +426,7 @@ class SettingsFragment : Fragment(),
     }
 
     private fun minutesToSlider(minutes: Int): Float {
-        val min = 15f
+        val min = FileCopyWorker.MIN_INTERVAL_MINUTES.toFloat()
         val max = 43200f
         val minLog = ln(min)
         val maxLog = ln(max)
@@ -435,7 +435,7 @@ class SettingsFragment : Fragment(),
     }
 
     private fun sliderToMinutes(value: Float): Int {
-        val min = 15f
+        val min = FileCopyWorker.MIN_INTERVAL_MINUTES.toFloat()
         val max = 43200f
         val minLog = ln(min)
         val maxLog = ln(max)

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -294,7 +294,7 @@ class SettingsFragment : Fragment(),
         if (prefs.getLong(FileCopyWorker.PREF_LAST_COPY, 0L) == 0L) {
             prefs.edit().putBoolean(FileCopyWorker.PREF_REQUIRE_MANUAL_FIRST, true).apply()
         }
-        val period = minutes.coerceAtLeast(3).toLong()
+        val period = minutes.coerceAtLeast(15).toLong()
         val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
             .addTag(FileCopyWorker.TAG)
             .build()
@@ -322,7 +322,7 @@ class SettingsFragment : Fragment(),
 
         if (toggle.isChecked) {
             val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
-            val period = minutes.coerceAtLeast(3).toLong()
+            val period = minutes.coerceAtLeast(15).toLong()
             val requestPeriodic =
                 PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
                     .addTag(FileCopyWorker.TAG)
@@ -426,7 +426,7 @@ class SettingsFragment : Fragment(),
     }
 
     private fun minutesToSlider(minutes: Int): Float {
-        val min = 3f
+        val min = 15f
         val max = 43200f
         val minLog = ln(min)
         val maxLog = ln(max)
@@ -435,7 +435,7 @@ class SettingsFragment : Fragment(),
     }
 
     private fun sliderToMinutes(value: Float): Int {
-        val min = 3f
+        val min = 15f
         val max = 43200f
         val minLog = ln(min)
         val maxLog = ln(max)


### PR DESCRIPTION
## Summary
- allow periodic work to run every 3 minutes
- prevent slider from selecting intervals below 3 minutes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687151824298832fb45657ce2eabac4e