### PR TITLE
Handle result notifications on boot and cancel

### DIFF
--- a/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
@@ -7,6 +7,7 @@ import android.preference.PreferenceManager
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import at.plankt0n.wamediacopy.StatusNotifier
 
 import java.util.concurrent.TimeUnit
 
@@ -15,6 +16,7 @@ class BootReceiver : BroadcastReceiver() {
         val action = intent.action
         if (action == Intent.ACTION_BOOT_COMPLETED ||
             action == Intent.ACTION_MY_PACKAGE_REPLACED) {
+            StatusNotifier.clearResult(context)
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)
             if (prefs.getBoolean(SettingsFragment.PREF_ENABLED, true)) {
                 val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)

--- a/app/src/main/java/at/plankt0n/wamediacopy/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import at.plankt0n.wamediacopy.FoldersFragment
 import at.plankt0n.wamediacopy.BlacklistFragment
 import at.plankt0n.wamediacopy.LogsFragment
+import at.plankt0n.wamediacopy.ReportsFragment
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,6 +31,7 @@ class MainActivity : AppCompatActivity() {
                 R.id.nav_folders -> FoldersFragment()
                 R.id.nav_blacklist -> BlacklistFragment()
                 R.id.nav_logs -> LogsFragment()
+                R.id.nav_reports -> ReportsFragment()
                 else -> null
             }
             fragment?.let {

--- a/app/src/main/java/at/plankt0n/wamediacopy/ReportStore.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/ReportStore.kt
@@ -1,0 +1,71 @@
+package at.plankt0n.wamediacopy
+
+import android.content.Context
+import android.preference.PreferenceManager
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Stores details about each copy run */
+object ReportStore {
+    private const val PREF_REPORTS = "copyReports"
+    private const val MAX_REPORTS = 20
+
+    data class CopyReport(
+        val timestamp: Long,
+        val copied: List<String>,
+        val old: List<String>,
+        val blacklisted: List<String>,
+    )
+
+    fun add(context: Context, report: CopyReport) {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val arr = JSONArray(prefs.getString(PREF_REPORTS, "[]"))
+        val obj = JSONObject().apply {
+            put("ts", report.timestamp)
+            put("copied", JSONArray(report.copied))
+            put("old", JSONArray(report.old))
+            put("black", JSONArray(report.blacklisted))
+        }
+        arr.put(obj)
+        if (arr.length() > MAX_REPORTS) {
+            val newArr = JSONArray()
+            for (i in arr.length() - MAX_REPORTS until arr.length()) {
+                newArr.put(arr.getJSONObject(i))
+            }
+            prefs.edit().putString(PREF_REPORTS, newArr.toString()).apply()
+        } else {
+            prefs.edit().putString(PREF_REPORTS, arr.toString()).apply()
+        }
+    }
+
+    fun get(context: Context): List<CopyReport> {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val arr = JSONArray(prefs.getString(PREF_REPORTS, "[]"))
+        val res = mutableListOf<CopyReport>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            res.add(
+                CopyReport(
+                    obj.getLong("ts"),
+                    obj.getJSONArray("copied").toList(),
+                    obj.getJSONArray("old").toList(),
+                    obj.getJSONArray("black").toList(),
+                )
+            )
+        }
+        return res
+    }
+
+    fun clear(context: Context) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+            .remove(PREF_REPORTS).apply()
+    }
+}
+
+private fun JSONArray.toList(): List<String> {
+    val res = mutableListOf<String>()
+    for (i in 0 until length()) {
+        res.add(getString(i))
+    }
+    return res
+}

--- a/app/src/main/java/at/plankt0n/wamediacopy/ReportStore.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/ReportStore.kt
@@ -48,7 +48,7 @@ object ReportStore {
             res.add(
                 CopyReport(
                     obj.getLong("ts"),
-                    obj.getString("file"),
+                    obj.optString("file"),
                     obj.optInt("c"),
                     obj.optInt("o"),
                     obj.optInt("s"),

--- a/app/src/main/java/at/plankt0n/wamediacopy/ReportsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/ReportsFragment.kt
@@ -9,6 +9,7 @@ import android.widget.ListView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import android.text.format.DateFormat
+import java.io.File
 
 class ReportsFragment : Fragment() {
 
@@ -32,17 +33,14 @@ class ReportsFragment : Fragment() {
         reportList.setOnItemClickListener { _, _, position, _ ->
             val rep = reports[position]
             val ts = DateFormat.format("yyyy-MM-dd HH:mm", rep.timestamp)
-            val msg = buildString {
-                append("Copied Files:\n")
-                rep.copied.forEach { append("- $it\n") }
-                append("\nToo Old:\n")
-                rep.old.forEach { append("- $it\n") }
-                append("\nBlacklisted Files:\n")
-                rep.blacklisted.forEach { append("- $it\n") }
+            val text = try {
+                File(rep.file).readText()
+            } catch (e: Exception) {
+                "Failed to read log"
             }
             AlertDialog.Builder(requireContext())
                 .setTitle(ts)
-                .setMessage(msg)
+                .setMessage(text)
                 .setPositiveButton(android.R.string.ok, null)
                 .show()
         }
@@ -62,6 +60,6 @@ class ReportsFragment : Fragment() {
 
     private fun summary(r: ReportStore.CopyReport): String {
         val ts = DateFormat.format("yyyy-MM-dd HH:mm", r.timestamp)
-        return "$ts - Copied:${r.copied.size} - Too Old:${r.old.size} - Blacklisted:${r.blacklisted.size}"
+        return "$ts - Copied:${r.copied} - Too Old:${r.old} - Blacklisted:${r.skipped}"
     }
 }

--- a/app/src/main/java/at/plankt0n/wamediacopy/ReportsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/ReportsFragment.kt
@@ -1,0 +1,67 @@
+package at.plankt0n.wamediacopy
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.ListView
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.Fragment
+import android.text.format.DateFormat
+
+class ReportsFragment : Fragment() {
+
+    private lateinit var reportList: ListView
+    private lateinit var adapter: ArrayAdapter<String>
+    private val reports = mutableListOf<ReportStore.CopyReport>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return inflater.inflate(R.layout.fragment_reports, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        reportList = view.findViewById(R.id.list_reports)
+        adapter = ArrayAdapter(requireContext(), R.layout.item_log, mutableListOf())
+        reportList.adapter = adapter
+        reportList.setOnItemClickListener { _, _, position, _ ->
+            val rep = reports[position]
+            val ts = DateFormat.format("yyyy-MM-dd HH:mm", rep.timestamp)
+            val msg = buildString {
+                append("Copied Files:\n")
+                rep.copied.forEach { append("- $it\n") }
+                append("\nToo Old:\n")
+                rep.old.forEach { append("- $it\n") }
+                append("\nBlacklisted Files:\n")
+                rep.blacklisted.forEach { append("- $it\n") }
+            }
+            AlertDialog.Builder(requireContext())
+                .setTitle(ts)
+                .setMessage(msg)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refresh()
+    }
+
+    private fun refresh() {
+        reports.clear()
+        reports.addAll(ReportStore.get(requireContext()).asReversed())
+        adapter.clear()
+        adapter.addAll(reports.map { summary(it) })
+    }
+
+    private fun summary(r: ReportStore.CopyReport): String {
+        val ts = DateFormat.format("yyyy-MM-dd HH:mm", r.timestamp)
+        return "$ts - Copied:${r.copied.size} - Too Old:${r.old.size} - Blacklisted:${r.blacklisted.size}"
+    }
+}

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -355,6 +355,7 @@ class SettingsFragment : Fragment(),
             .remove(FileCopyWorker.PREF_PROCESSED)
             .apply()
         StatusNotifier.hideService(requireContext())
+        StatusNotifier.clearResult(requireContext())
         refreshLastCopy(prefs)
     }
 

--- a/app/src/main/java/at/plankt0n/wamediacopy/StatusNotifier.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/StatusNotifier.kt
@@ -38,6 +38,10 @@ object StatusNotifier {
         NotificationManagerCompat.from(context).notify(RESULT_ID, notif)
     }
 
+    fun clearResult(context: Context) {
+        NotificationManagerCompat.from(context).cancel(RESULT_ID)
+    }
+
     fun hideService(context: Context) {
         val nm = NotificationManagerCompat.from(context)
         nm.cancel(SERVICE_ID)

--- a/app/src/main/res/layout/fragment_reports.xml
+++ b/app/src/main/res/layout/fragment_reports.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ListView
+        android:id="@+id/list_reports"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:dividerHeight="4dp" />
+</LinearLayout>

--- a/app/src/main/res/menu/bottom_nav.xml
+++ b/app/src/main/res/menu/bottom_nav.xml
@@ -15,4 +15,8 @@
         android:id="@+id/nav_logs"
         android:icon="@android:drawable/ic_menu_info_details"
         android:title="Logs" />
+    <item
+        android:id="@+id/nav_reports"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="Reports" />
 </menu>


### PR DESCRIPTION
## Summary
- allow clearing of result notification
- wipe any result notifications when booting
- dismiss result when cancelling work

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716a418654832fbd3813a1c44e027f