### PR TITLE
Add skip folder support

### DIFF
--- a/app/src/main/java/at/plankt0n/wamediacopy/CopyReports.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/CopyReports.kt
@@ -1,0 +1,40 @@
+package at.plankt0n.wamediacopy
+
+import android.content.Context
+import android.preference.PreferenceManager
+import android.text.format.DateFormat
+
+object CopyReports {
+    private const val PREF_REPORTS = "reports"
+    private const val MAX_LINES = 100
+
+    fun add(
+        context: Context,
+        start: Long,
+        end: Long,
+        copied: Long,
+        old: Long,
+        exist: Long,
+        black: Long
+    ) {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val existing = prefs.getString(PREF_REPORTS, "") ?: ""
+        val startStr = DateFormat.format("yyyy-MM-dd HH:mm:ss", start)
+        val endStr = DateFormat.format("yyyy-MM-dd HH:mm:ss", end)
+        val line = "$startStr - $endStr Copied:$copied Skipped old:$old Skipped existed:$exist Skipped blacklisted:$black"
+        val lines = if (existing.isBlank()) emptyList() else existing.split('\n')
+        val updated = (lines + line).takeLast(MAX_LINES).joinToString("\n")
+        prefs.edit().putString(PREF_REPORTS, updated).apply()
+    }
+
+    fun get(context: Context): List<String> {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val data = prefs.getString(PREF_REPORTS, "") ?: ""
+        return if (data.isBlank()) emptyList() else data.split('\n')
+    }
+
+    fun clear(context: Context) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit().remove(PREF_REPORTS).apply()
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -62,6 +62,7 @@ class FileCopyWorker(
         var newCount = 0L
         var oldSkipped = 0L
         var alreadySkipped = 0L
+        var existingSkipped = 0L
         var processed = 0L
         var newestOldName: String? = null
         var newestOldTime = 0L
@@ -72,6 +73,7 @@ class FileCopyWorker(
             .putLong(PREF_COUNT_COPIED, 0L)
             .putLong(PREF_COUNT_OLD, 0L)
             .putLong(PREF_COUNT_SKIPPED, 0L)
+            .putLong(PREF_COUNT_EXISTING, 0L)
             .putBoolean(PREF_STOP_REQUESTED, false)
             .apply()
         setForeground(createForegroundInfo(0L))
@@ -146,7 +148,11 @@ class FileCopyWorker(
                                     Log.d(TAG, "Exists elsewhere")
                                     AppLog.add(applicationContext, "skipped existfile")
                                     alreadySkipped++
-                                    prefs.edit().putLong(PREF_COUNT_SKIPPED, alreadySkipped).apply()
+                                    existingSkipped++
+                                    prefs.edit()
+                                        .putLong(PREF_COUNT_SKIPPED, alreadySkipped)
+                                        .putLong(PREF_COUNT_EXISTING, existingSkipped)
+                                        .apply()
                                     continue
                                 }
                                 var targetName = finalName
@@ -229,8 +235,8 @@ class FileCopyWorker(
                 .putLong(PREF_LAST_COPY, now)
                 .apply()
 
-            val summary = "Copied:$newCount - Too Old:$oldSkipped - Skipped:$alreadySkipped"
-            StatusNotifier.showResult(applicationContext, newCount, oldSkipped, alreadySkipped)
+            val summary = "Copied:$newCount - Too Old:$oldSkipped - Skipped existing:$existingSkipped - Skipped:$alreadySkipped"
+            StatusNotifier.showResult(applicationContext, newCount, oldSkipped, existingSkipped, alreadySkipped)
             AppLog.add(applicationContext, summary)
 
             if (intervalMin > 0) {
@@ -256,6 +262,7 @@ class FileCopyWorker(
                 .remove(PREF_COUNT_COPIED)
                 .remove(PREF_COUNT_OLD)
                 .remove(PREF_COUNT_SKIPPED)
+                .remove(PREF_COUNT_EXISTING)
                 .putBoolean(PREF_STOP_REQUESTED, false)
                 .apply()
         }
@@ -290,6 +297,7 @@ class FileCopyWorker(
         const val PREF_COUNT_COPIED = "countCopied"
         const val PREF_COUNT_OLD = "countOld"
         const val PREF_COUNT_SKIPPED = "countSkipped"
+        const val PREF_COUNT_EXISTING = "countExisting"
         const val PREF_REQUIRE_MANUAL_FIRST = "requireManual"
         const val PREF_STOP_REQUESTED = "stopRequested"
         const val KEY_MANUAL = "manual"

--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -155,16 +155,17 @@ class FileCopyWorker(
                             val finalName = if (alias.isNotBlank()) alias + name else name
                             val existsElsewhere = existDirs.any { it.findFile(finalName) != null }
                             if (existsElsewhere) {
-                                    Log.d(TAG, "Exists elsewhere")
-                                    AppLog.add(applicationContext, "skipped existfile")
-                                    alreadySkipped++
-                                    existingSkipped++
-                                    prefs.edit()
-                                        .putLong(PREF_COUNT_SKIPPED, alreadySkipped)
-                                        .putLong(PREF_COUNT_EXISTING, existingSkipped)
-                                        .apply()
-                                    continue
-                                }
+                                Log.d(TAG, "Exists elsewhere")
+                                AppLog.add(applicationContext, "skipped existfile")
+                                alreadySkipped++
+                                existingSkipped++
+                                copied.add(key)
+                                prefs.edit()
+                                    .putLong(PREF_COUNT_SKIPPED, alreadySkipped)
+                                    .putLong(PREF_COUNT_EXISTING, existingSkipped)
+                                    .apply()
+                                continue
+                            }
                                 var targetName = finalName
                                 var target = destDir.findFile(targetName)
                                 if (target != null) {

--- a/app/src/main/java/at/plankt0n/wamediacopy/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import at.plankt0n.wamediacopy.FoldersFragment
 import at.plankt0n.wamediacopy.BlacklistFragment
 import at.plankt0n.wamediacopy.LogsFragment
+import at.plankt0n.wamediacopy.ReportsFragment
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,6 +31,7 @@ class MainActivity : AppCompatActivity() {
                 R.id.nav_folders -> FoldersFragment()
                 R.id.nav_blacklist -> BlacklistFragment()
                 R.id.nav_logs -> LogsFragment()
+                R.id.nav_reports -> ReportsFragment()
                 else -> null
             }
             fragment?.let {

--- a/app/src/main/java/at/plankt0n/wamediacopy/ReportsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/ReportsFragment.kt
@@ -1,0 +1,51 @@
+package at.plankt0n.wamediacopy
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Button
+import android.widget.ListView
+import androidx.fragment.app.Fragment
+
+class ReportsFragment : Fragment() {
+
+    private lateinit var reportList: ListView
+    private lateinit var adapter: ArrayAdapter<String>
+    private lateinit var clearButton: Button
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_reports, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        reportList = view.findViewById(R.id.list_reports)
+        clearButton = view.findViewById(R.id.button_clear_reports)
+
+        adapter = ArrayAdapter(requireContext(), R.layout.item_log, mutableListOf())
+        reportList.adapter = adapter
+
+        clearButton.setOnClickListener {
+            CopyReports.clear(requireContext())
+            refresh()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refresh()
+    }
+
+    private fun refresh() {
+        val lines = CopyReports.get(requireContext()).asReversed()
+        adapter.clear()
+        adapter.addAll(lines)
+    }
+}
+

--- a/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/SettingsFragment.kt
@@ -193,6 +193,7 @@ class SettingsFragment : Fragment(),
         val processed = prefs.getLong(FileCopyWorker.PREF_PROCESSED, 0L)
         val copied = prefs.getLong(FileCopyWorker.PREF_COUNT_COPIED, 0L)
         val skipped = prefs.getLong(FileCopyWorker.PREF_COUNT_SKIPPED, 0L)
+        val existSkipped = prefs.getLong(FileCopyWorker.PREF_COUNT_EXISTING, 0L)
         val old = prefs.getLong(FileCopyWorker.PREF_COUNT_OLD, 0L)
 
         manual.isEnabled = !running
@@ -205,7 +206,7 @@ class SettingsFragment : Fragment(),
 
         val base = "$lastLabel\n$nextLabel"
         val combined = if (running) {
-            "$base\nProcessed: $processed\nCopied: $copied\nSkipped: $skipped\nToo old: $old"
+            "$base\nProcessed: $processed\nCopied: $copied\nSkipped existing: $existSkipped\nSkipped: $skipped\nToo old: $old"
         } else base
         lastCopyText.text = combined
         refreshAge()
@@ -380,6 +381,7 @@ class SettingsFragment : Fragment(),
             key == FileCopyWorker.PREF_COPY_MODE ||
             key == FileCopyWorker.PREF_COUNT_COPIED ||
             key == FileCopyWorker.PREF_COUNT_SKIPPED ||
+            key == FileCopyWorker.PREF_COUNT_EXISTING ||
             key == FileCopyWorker.PREF_COUNT_OLD) {
             refreshLastCopy(prefs)
         }

--- a/app/src/main/java/at/plankt0n/wamediacopy/StatusNotifier.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/StatusNotifier.kt
@@ -25,11 +25,11 @@ object StatusNotifier {
         NotificationManagerCompat.from(context).notify(SERVICE_ID, notif)
     }
 
-    fun showResult(context: Context, copied: Long, old: Long, skipped: Long) {
+    fun showResult(context: Context, copied: Long, old: Long, exist: Long, skipped: Long) {
         val channel = NotificationChannel(CHANNEL_ID, "Copy status", NotificationManager.IMPORTANCE_LOW)
         val nm = context.getSystemService(NotificationManager::class.java)
         nm.createNotificationChannel(channel)
-        val text = "Copied:$copied - Too Old:$old - Skipped:$skipped"
+        val text = "Copied:$copied - Too Old:$old - Skipped existing:$exist - Skipped:$skipped"
         val notif = NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle("Whatsapp Copy: Copy Finished")
             .setContentText(text)

--- a/app/src/main/res/layout/fragment_folders.xml
+++ b/app/src/main/res/layout/fragment_folders.xml
@@ -41,5 +41,19 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/layout_exist"
+            android:orientation="vertical"
+            android:layout_marginTop="8dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/button_add_exist"
+            android:text="Add existing folder"
+            android:layout_marginTop="4dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_reports.xml
+++ b/app/src/main/res/layout/fragment_reports.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <ListView
+        android:id="@+id/list_reports"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:transcriptMode="normal"
+        android:stackFromBottom="false"
+        android:dividerHeight="4dp" />
+
+    <Button
+        android:id="@+id/button_clear_reports"
+        android:text="Clear reports"
+        android:layout_marginTop="8dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+</LinearLayout>
+

--- a/app/src/main/res/menu/bottom_nav.xml
+++ b/app/src/main/res/menu/bottom_nav.xml
@@ -15,4 +15,8 @@
         android:id="@+id/nav_logs"
         android:icon="@android:drawable/ic_menu_info_details"
         android:title="Logs" />
+    <item
+        android:id="@+id/nav_reports"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="Berichte" />
 </menu>


### PR DESCRIPTION
## Summary
- allow managing extra folders that cause skipping copies
- skip files if they already exist in any configured folder

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68721c31fbb0832fb361237605f0e48d