### PR TITLE
Fix BootReceiver WorkManager tag

### DIFF
--- a/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/BootReceiver.kt
@@ -19,7 +19,9 @@ class BootReceiver : BroadcastReceiver() {
             if (prefs.getBoolean(SettingsFragment.PREF_ENABLED, true)) {
                 val minutes = prefs.getInt(FileCopyWorker.PREF_INTERVAL_MINUTES, 720)
                 val period = minutes.coerceAtLeast(FileCopyWorker.MIN_INTERVAL_MINUTES).toLong()
-                val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES).build()
+                val request = PeriodicWorkRequestBuilder<FileCopyWorker>(period, TimeUnit.MINUTES)
+                    .addTag(FileCopyWorker.TAG)
+                    .build()
                 WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                     SettingsFragment.WORK_NAME,
                     ExistingPeriodicWorkPolicy.UPDATE,

--- a/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FileCopyWorker.kt
@@ -273,6 +273,7 @@ class FileCopyWorker(
                 .remove(PREF_COUNT_BLACKLISTED)
                 .putBoolean(PREF_STOP_REQUESTED, false)
                 .apply()
+            StatusNotifier.hideService(applicationContext)
         }
     }
 

--- a/app/src/main/java/at/plankt0n/wamediacopy/FoldersFragment.kt
+++ b/app/src/main/java/at/plankt0n/wamediacopy/FoldersFragment.kt
@@ -56,6 +56,8 @@ class FoldersFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeLi
         existing.addAll(prefs.getStringSet(FileCopyWorker.PREF_EXISTING_DIRS, emptySet()) ?: emptySet())
         refreshExisting(prefs)
         destEdit.setText(Uri.decode(prefs.getString(FileCopyWorker.PREF_DEST, "")))
+        destEdit.setSingleLine(true)
+        destEdit.setHorizontallyScrolling(true)
 
         addSource.setOnClickListener {
             Log.d(TAG, "add source pressed")
@@ -90,7 +92,10 @@ class FoldersFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeLi
             val row = LinearLayout(requireContext()).apply { orientation = LinearLayout.HORIZONTAL }
             val tv = TextView(requireContext()).apply {
                 text = Uri.decode(uri)
+            }
+            val scroll = android.widget.HorizontalScrollView(requireContext()).apply {
                 layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                addView(tv)
             }
             val remove = Button(requireContext()).apply { text = "X" }
             remove.setOnClickListener {
@@ -101,7 +106,7 @@ class FoldersFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeLi
                 refreshSources(prefs)
                 AppLog.add(requireContext(), "Removed source $decoded")
             }
-            row.addView(tv)
+            row.addView(scroll)
             row.addView(remove)
             sourcesLayout.addView(row)
         }
@@ -112,9 +117,10 @@ class FoldersFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeLi
         existLayout.removeAllViews()
         for (uri in existing) {
             val row = LinearLayout(requireContext()).apply { orientation = LinearLayout.HORIZONTAL }
-            val tv = TextView(requireContext()).apply {
-                text = Uri.decode(uri)
+            val tv = TextView(requireContext()).apply { text = Uri.decode(uri) }
+            val scroll = android.widget.HorizontalScrollView(requireContext()).apply {
                 layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                addView(tv)
             }
             val remove = Button(requireContext()).apply { text = "X" }
             remove.setOnClickListener {
@@ -125,7 +131,7 @@ class FoldersFragment : Fragment(), SharedPreferences.OnSharedPreferenceChangeLi
                 refreshExisting(prefs)
                 AppLog.add(requireContext(), "Removed existing $decoded")
             }
-            row.addView(tv)
+            row.addView(scroll)
             row.addView(remove)
             existLayout.addView(row)
         }

--- a/app/src/main/res/layout/fragment_folders.xml
+++ b/app/src/main/res/layout/fragment_folders.xml
@@ -8,6 +8,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Source Folders:" />
+
         <LinearLayout
             android:id="@+id/layout_sources"
             android:orientation="vertical"
@@ -21,9 +26,15 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Destination Folder:" />
+
         <LinearLayout
             android:orientation="horizontal"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="4dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
             <EditText
@@ -41,10 +52,16 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Skip if File is present here:" />
+
         <LinearLayout
             android:id="@+id/layout_exist"
             android:orientation="vertical"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="4dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 


### PR DESCRIPTION
## Summary
- ensure BootReceiver adds `FileCopyWorker.TAG` when rescheduling work
- improve Folders screen UI with section headings and horizontally scrollable paths
- clear the foreground progress notification when a copy completes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687294ae58dc832f84b8b03e9111a2db